### PR TITLE
GPS-835: Add bug test entry to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ test
 test
 
 - test entry for feature category (2026-07-15T12:14:49Z)
+- test entry for bug category (2026-07-15T12:16:59Z)


### PR DESCRIPTION
Testing PR content/label enforcement and release notes categorization for the 'bug' label, part of GPS-835.