### PR TITLE
GPS-835: Add breaking-change test entry to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ test
 - test entry for feature category (2026-07-15T12:14:49Z)
 - test entry for bug category (2026-07-15T12:16:59Z)
 - test entry for data-integration category (2026-07-15T12:17:08Z)
+- test entry for breaking-change category (2026-07-15T12:17:17Z)


### PR DESCRIPTION
Testing PR content/label enforcement and release notes categorization for the 'breaking-change' label, part of GPS-835.