### PR TITLE
GPS-835: Add dependencies test entry to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ test
 - test entry for bug category (2026-07-15T12:16:59Z)
 - test entry for data-integration category (2026-07-15T12:17:08Z)
 - test entry for breaking-change category (2026-07-15T12:17:17Z)
+- test entry for dependencies category (2026-07-15T12:17:25Z)


### PR DESCRIPTION
Testing PR content/label enforcement and release notes categorization for the 'dependencies' label, part of GPS-835.